### PR TITLE
docs: streamline RCN onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,185 +1,67 @@
 # Rust Commercial Network (RCN)
 
-Where companies and communities work together to advance Rust adoption. 
+Where Rust users, businesses, and communities work together to make Rust easier to adopt and maintain.
 
-**To join the RCN, please fill out the [application](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=membership%2Cstatus%3A+needs+review&projects=&template=membership.yml). You will be sent an invitation to Zulip, added to the RCN Channel, and listed as a member.**
+The Rust Commercial Network (RCN) is a Rust Foundation group for people and organizations using Rust in professional settings. Members compare notes on adoption blockers, improve Rust supply chain health, and support the basic tooling, libraries, and maintenance work that make Rust dependable in production.
+
+**Join:** fill out the [membership application](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=membership%2Cstatus%3A+needs+review&projects=&template=membership.yml).
+
+**Discuss:** use the RCN channel in the [Rust Project Zulip](https://rust-lang.zulipchat.com/).
 
 ## Overview
 
-The Rust Commercial Network (RCN), facilitated by the Rust Foundation, is composed of Rust Foundation Members, Rust Advocates within their companies/industry, Rust Project Members, and individuals that represent commercial companies, industries, academia, and organizations that are using Rust or looking to adopt Rust. The RCN is the umbrella network that houses the RCN’s industry consortiums, working groups, etc and their work is overseen by the RCN Steering Committee. This is not to be confused with the Rust Project’s developing [Rust Society](https://github.com/jamesmunns/rust-society/blob/main/reports/pdf/2025-04-04.pdf) that is run by the Rust Project, although there may be some overlap over time.
+The RCN is open to Rust users of all sizes: individual commercial users, consultants, startups, small businesses, larger companies, academic users, organizations, Rust Foundation Members, Rust Advocates, and members of the Rust Project. The RCN supports industry consortiums and working groups, with review from the RCN Steering Committee.
 
-The RCN is designed to be a community of industry professionals, thought leaders, and Rust Project members sharing their experiences adopting Rust and using it in production. 
+The RCN is separate from the Rust Project’s developing [Rust Society](https://github.com/jamesmunns/rust-society/blob/main/reports/pdf/2025-04-04.pdf), although there may be some overlap over time.
 
 Membership in the RCN is free.
 
-The mission of the RCN includes:
+The RCN works to:
 
-* Starting consortiums and working groups to focus on industry-specific challenges  
-* Improving visibility into Rust adoption among commercial, industrial, and organizational users  
-* Identifying unmet needs of Rust users   
-* Offering feedback on the usability, reliability, and performance of Rust and the ecosystem  
-* Facilitating a closer relationship between the Project, the Foundation, and commercial, industrial, and organizational users of Rust  
-* Developing pathways to contributions within the Rust Project and Ecosystem   
-* Collaborating with the Rust Project
+* Identify Rust adoption and maintenance problems shared by production users
+* Form working groups around industry-specific or ecosystem-wide needs
+* Help members contribute time, funding, testing, documentation, and maintainer support
+* Share findings with the Rust Project, ecosystem maintainers, and the Rust Foundation
 
-The RCN is a community initiative focused on professional users of Rust. The RCN is open to all commercial, industrial, academic, and organizational users of Rust and members of the Rust Project. 
+## What Members Do
 
-## Types of Activities
+* Meet regularly
+* Discuss topics that matter to production Rust users
+* Promote industry-specific adoption of Rust
+* Meet in person when possible, including at Rust Foundation events such as the Member Summit
+* Work with the Rust Project and ecosystem maintainers to identify and resolve issues that affect commercial and organizational use, including tooling gaps, crate reliability, maintenance bottlenecks, and adoption papercuts
+  * Members may contribute engineering time, funding, testing, maintainer support, documentation work, contributions to the Rust Foundation Maintainer’s Fund, or other help
 
-* Have meetings on a regular cadence
-* Proactively address topics of interest to those using Rust in production  
-* Promote industry specific adoption of Rust  
-* Meet in person at the Rust Foundation Member Summit (attached to RustConf)  
-* Working with the Rust project to identify how best to support the language’s development so that issues affecting commercial and organizational use and adoption are resolved  
-  * Such as providing testing, contributions to the Rust Foundation Maintainer’s Fund, engineering resources, etc.
+### RCN working groups may produce:
 
-### Examples of RCN outputs may include:
+* Best practice guides and reference architectures
+* Adoption playbooks
+* Feedback summaries for the Rust Project
+* Gap analyses for tooling, libraries, documentation, and maintenance capacity
+* Prioritized lists of papercuts and reliability issues affecting production users
+* Recommendations to improve core tooling, widely used libraries, crate reliability, long-term maintenance, and Rust supply chain health
 
-* Best practice guides and reference architectures  
-* Adoption playbooks  
-* Feedback summaries for the Rust Project  
-* Recommendations to improve ecosystem tooling and crates reliability
+\*Individual issues can be brought up to the Project independent of the RCN. The RCN aims to identify recurring or broadly shared issues, including smaller papercuts that add up to adoption, reliability, or maintenance problems across organizations.
 
-\*Individual issues can be brought up to the Project independent of the RCN. The RCN aims to discuss larger, overarching topics that can affect adoption or usage. 
+## Working Groups and Consortiums
 
-## Consortium and Working Groups
+RCN members can propose consortiums or working groups focused on shared adoption blockers, ecosystem maintenance, or industry-specific needs. These groups can produce guides, reports, recommendations, or other outputs for the Rust community.
 
-RCN members can propose consortiums or working groups focused on specific topics to the Steering Committee. These groups will have a unified focus and will report findings back to the Steering Committee and will operate under the guidelines listed below.
+To propose a group, [file an application using the GitHub Issue template](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=consortium-or-wg-proposal%2Cstatus%3A+needs+review&projects=&template=consortium_wg_proposal.yml). See [Working Groups and Consortiums](docs/working-groups.md) for operations, Steering Committee scope, voting rights, and withdrawal details.
 
+## Meetings and Communication
 
-### Consortium and Working Group Operations
+The RCN hosts public monthly meeting(s)\* to discuss topics related to production Rust users. The meetings take place on Google Meet. The RCN may use Chatham House Rule when meetings cover sensitive topics.
 
-Each consortium and working group defines and administers its own membership criteria, tiers, and processes. Conversely, membership in an RCN consortium or working group does not necessarily require RCN membership.
-
-### Membership
-
-Membership in the RCN and membership in an RCN consortium or working group are independent. RCN membership does not confer membership, standing, or participation rights in any consortium or working group. 
-
-### Proposing a Consortium and Working Group
-
-To propose a consortium or working group, please [file an application using the GitHub Issue template provided here](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=consortium-or-wg-proposal%2Cstatus%3A+needs+review&projects=&template=consortium_wg_proposal.yml).
-
-## RCN Member Definitions
-
-### Rust Foundation Member
-
-Individual representing a company that is a [member of the Rust Foundation](https://rustfoundation.org/members/) in good standing.
-
-### Commercial/Organizational Member
-
-A Rust Commercial/Organizational Member is defined as an individual in a company or organization that utilizes the Rust programming language or would like to adopt Rust to build software applications, systems, and or services including but not limited to consulting, training, and education. Rust Commercial/Organizational Members use Rust in production, may have contributed to the Rust Project, Crates.io, or created their own projects built in Rust. 
-
-### Rust Advocate
-
-Rust Advocates are individuals that have expertise using Rust to write applications and work in various industries and technology spaces such as Robotics, Automotive, Public Sector and cloud native. These advocates have been sourced from participation in RustConf and other Rust Foundation initiatives. Rust Advocates are thought leaders, Rust Foundation supporters, and may or may not be Rust Project members.
-
-### Rust Project Member
-
-Rust Project Members are individuals on a [Rust Team](https://rust-lang.org/governance/teams/) who make significant contributions to the development and maintenance of the Rust programming language and its associated tools.
-
-### Consortium/Working Group Member
-
-A Consortium/Working Group Member is an individual who is an active member of an RCN-affiliated consortium or working group, as determined by that group's own membership criteria and processes. Consortium/Working Group Members are recognized as RCN participants and may attend RCN meetings, contribute to discussions, and access RCN communication channels.
-
-Consortium/Working Group Members may vote on RCN matters that directly affect the consortium or working group in which they hold membership, including but not limited to: policies governing consortium operations, changes to the relationship between the RCN and its consortiums or working groups, and amendments to this charter that alter the rights or obligations of consortiums or working groups.
-
-Consortium/Working Group Members do not vote in RCN-wide elections such as Steering Committee seats unless they independently qualify under another RCN member definition.
-
-For the purposes of determining good standing, Consortium/Working Group Members must meet the membership requirements of their respective consortium or working group. Attendance at RCN-level meetings is not required for Consortium/Working Group Members to maintain good standing.
-
-### Governance boundary
-
-The RCN Steering Committee's oversight of consortiums and working groups pertains to coordination, alignment with the RCN's mission, and ensuring work is documented and publicly available. The SC does not have authority over a consortium's or working group's internal membership decisions, leadership selection, technical direction, or public communications.
-
-For the avoidance of doubt, "alignment with the RCN's mission" means that the consortium or working group operates within the broad domain of Rust adoption by commercial, industrial, or organizational users. It does not authorize the SC to require changes to a consortium's or working group's scope, priorities, deliverables, publication schedule, or processes in order to maintain affiliation.
-
-### Voting rights
-
-Only RCN members in good standing may vote in RCN-level elections (such as SC seats). Only consortium/working group members may vote in consortium/working group-level decisions, as defined by that group's own governance.
-
-### Existing groups
-
-Consortiums and working groups that predate the RCN or that maintain their own governance structures retain full authority over their technical outputs, publication decisions, and operational processes. The SC may not condition continued RCN affiliation on changes to a consortium's existing governance, scope, processes, or external relationships (including direct relationships with the Rust Project, standards bodies, or other organizations).
-
-### Withdrawal
-
-An RCN-affiliated consortium or working group may withdraw from the RCN at any time by written notice from that group's leadership to the RCN Steering Committee. Upon withdrawal, the consortium or working group retains its existing governance structures, membership, repositories, branding, and intellectual property. Withdrawal does not require SC approval. Former RCN-affiliated groups are welcome to seek re-affiliation in the future.
-
-## Meetings
-
-The RCN aims to create a safe and neutral space for discussing what can at times be sensitive topics. We propose to have a meeting policy to follow Chatham House Rule. The intent is to allow participants to feel comfortable with being candid and foster open collaboration. The RCN will host public monthly meeting(s)\* to discuss topics related to end users of Rust. The meetings will take place on Google Meet.
+Public discussion happens in the RCN channel in the [Rust Project Zulip](https://rust-lang.zulipchat.com/). See [Meetings](docs/meetings.md) for meeting policy, note-taking, and communication details.
 
 \*The RCN will determine the cadence and number of meetings per year.
 
-#### Chatham House Rule
+## Member Definitions and Governance
 
-[Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule) which essentially means:
+RCN membership is free. See [Membership](docs/membership.md) for member definitions, including Rust Foundation Members, Commercial/Organizational Members, Rust Advocates, Rust Project Members, and Consortium/Working Group Members.
 
-Its guiding spirit is: share the information you receive, but do not reveal the identity of who said it.
-
-Following somewhat from above in following Chatham House Rule, *we prohibit taking screen or voice recordings*. *We also disallow any other means of taking transcriptions, such as AI bots*.
-
-### Meeting Option
-
-If the RCN determines that they do not need to follow Chatham House Rule to be able to speak openly we will remove this proposed policy and will allow for transcriptions and recordings based on the wants of the group. 
-
-### Notetaker Role
-
-Each meeting a representative from the Rust Foundation or an attendee will be asked to take meeting notes. See the [notetaker.md](./docs/notetaker-role.md) doc for more details and information.
-
-### Communication
-
-The RCN will have a Zulip channel in the [Rust Project Zulip](https://rust-lang.zulipchat.com/) dedicated to fostering async collaboration and setting up topics for discussion. RCN members are encouraged to join the channel and create discussion threads that are accessible to anyone in Zulip. Zulip is a public forum with members of the Rust Project, guests of the Project, end users, and Rust Foundation staff; threads are publicly accessible. Private channels may be necessary to discuss sensitive topics but the preference is to keep all conversations out in the open which is aligned to how the Project operates.
-
-## Governance
-
-The RCN is a volunteer driven community maintained by the Rust Foundation. The RCN consists of the membership, a Steering Committee, and the consortiums and working groups that the Steering Committee creates and oversees. You can be a member of the RCN to network with your peers \- you do not need to join a consortium and or working group.
-
-### RCN Steering Committee
-
-#### Purpose and Duties
-
-The RCN Steering Committee is tasked with:
-
-1. Act as representatives of the RCN to the Rust Foundation Board, conferences, media requests  
-2. Act as a lobbying body to the Rust Project to express needs of users and work to find solutions with the Project. The SC does not speak on behalf of any consortium or working group to the Rust Project or external bodies without that group's explicit consent.  
-3. Voting on and approving/rejecting the creation of RCN topic specific consortiums/working groups, subject to the provisions in Consortium and Working Group Operations  
-4. Develop policies and procedures consistent with this charter  
-5. Providing oversight for RCN consortiums/working groups, as defined in Consortium and Working Group Operations  
-6. Ensuring that the work of the RCN is documented and publicly available
-
-#### Composition and Selection
-
-Voting on the RCN Steering Committee members will be done by RCN members in good standing. A member in good standing has attended at least 2 RCN meetings and is officially listed on the RCN GitHub Repo as a RCN member. For a listing of Rust Foundation Members visit https://rustfoundation.org/members/.
-
-#### The RCN Steering Committee consists of:
-
-* No more than seven and no less than five representatives from Platinum (1), Gold (1) , Silver (2), and Associate (1) Rust Foundation members. There cannot be two Steering Committee Members from one company.  
-* The Rust Foundation will have a seat on the Steering Committee in an advisory capacity.  
-* The Rust Project will have a seat on the Steering Committee in an advisory capacity.
-
-#### Terms and Termination
-
-* RCN SC Members serve approximately two-year terms, with staggered terms initially.  
-* RCN SC Membership ceases if a member resigns, is removed, or changes employment away from a Rust Foundation member. A super-majority vote can remove members not fulfilling their duties or complying with RCN policies.
-
-#### Vacancies and Alternates
-
-* Vacancies that would put steering committee membership below five (5) are filled by election or invitation.
-
-#### Eligibility and Criteria
-
-* Members must be employees of Rust Foundation Membership companies in good standing.  
-* Only one representative from the same organization may serve at a time.
-
-### RCN Consortiums/Working Groups
-
-General members of the RCN that would like to focus on a specific topic related to use or adoption of Rust and/or the Rust Ecosystem will propose the formation of these subgroups to the RCN Steering Committee. Areas to address include:
-
-* Identifying shared challenges in Rust adoption and crate maintenance  
-* Creating high-level frameworks or templates to help others adopt Rust  
-* Exploring what the commercial/industry community would like to have/needs to build greater adoption of Rust   
-* Highlighting popular and/or innovative projects that are not in the [Rust Innovation Lab (RIL)](https://rustfoundation.org/rust-innovation-lab/) that would benefit the Rust community if given a larger platform for development and support by joining the RIL
+The Rust Foundation maintains the RCN with support from the RCN Steering Committee. See [Governance](docs/governance.md) for Steering Committee duties, composition, selection, terms, vacancies, and eligibility.
 
 ## [Code of Conduct](https://foundation.rust-lang.org/policies/code-of-conduct/)
 
@@ -187,13 +69,13 @@ The [Rust Foundation](https://rustfoundation.org/) has adopted a Code of Conduct
 
 ## Community Events
 
-### Rust Foundation Member Summit
+The Rust Foundation Member Summit, attached to RustConf, may provide one place for RCN members, Rust Foundation members, Rust Foundation Board Members, and Rust Project members to meet in person.
 
-This is an invite only, in-person event and is coupled with RustConf. This one day event will have a light agenda and will foster in-person collaboration with RCN members, Rust Foundation members that may not be active in the RCN, Rust Foundation Board Members, and members of the Rust Project. Meeting logistics and rules will be decided closer to the event.
+## Next Steps
 
-## How to Join the RCN 
-
-Fill out the [application](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=membership%2Cstatus%3A+needs+review&projects=&template=membership.yml). You will be sent an invitation to Zulip, added to the RCN Channel, and listed as a member.
+* [Apply to join the RCN](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=membership%2Cstatus%3A+needs+review&projects=&template=membership.yml)
+* [Propose a working group or consortium](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=consortium-or-wg-proposal%2Cstatus%3A+needs+review&projects=&template=consortium_wg_proposal.yml)
+* Join the RCN channel in the [Rust Project Zulip](https://rust-lang.zulipchat.com/)
 
 ## Contributing
 
@@ -203,7 +85,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 Rust is primarily distributed under the terms of both the MIT license and the
 Apache License (Version 2.0), with documentation portions covered by the
-Creative Commons Attribution 4.0 International license..
+Creative Commons Attribution 4.0 International license.
 
 See [LICENSE-APACHE](LICENSE-APACHE), [LICENSE-MIT](LICENSE-MIT),
 [LICENSE-documentation](LICENSE-documentation), and
@@ -214,7 +96,7 @@ policy][ip-policy].
 
 ## Other Policies
 
-Members of the RCN mustl adhere to the Rust Foundation’s anti-trust policy [https://rustfoundation.org/policy/anti-trust-policy/](https://rustfoundation.org/policy/anti-trust-policy/) as you are a participant in the Foundation. Additional policies can be found on the [Rust Foundation website](https://rustfoundation.org/policies-resources/).  
+Members of the RCN must adhere to the Rust Foundation’s anti-trust policy [https://rustfoundation.org/policy/anti-trust-policy/](https://rustfoundation.org/policy/anti-trust-policy/) as you are a participant in the Foundation. Additional policies can be found on the [Rust Foundation website](https://rustfoundation.org/policies-resources/).
 
 [code-of-conduct]: https://rustfoundation.org/policy/code-of-conduct/
 [ip-policy]: https://rustfoundation.org/policy/intellectual-property-policy/

--- a/docs/governance.md
+++ b/docs/governance.md
@@ -1,0 +1,40 @@
+# RCN Governance
+
+The RCN is a volunteer-driven community maintained by the Rust Foundation. It consists of the membership, a Steering Committee, and the consortiums and working groups that the Steering Committee approves and reviews. You can be a member of the RCN without joining a consortium or working group.
+
+## RCN Steering Committee
+
+### Purpose and Duties
+
+The RCN Steering Committee:
+
+1. Represents the RCN to the Rust Foundation Board, conferences, and media
+2. Shares user needs with the Rust Project and works with Project members on possible solutions. The SC does not speak on behalf of any consortium or working group to the Rust Project or external bodies without that group's explicit consent.
+3. Reviews and votes on proposed RCN consortiums and working groups
+4. Develops policies and procedures consistent with this charter
+5. Reviews RCN consortiums and working groups
+6. Keeps RCN work documented and public
+
+### Composition and Selection
+
+RCN members in good standing vote on RCN Steering Committee members. A member in good standing has attended at least 2 RCN meetings and is officially listed on the RCN GitHub Repo as a RCN member. For a listing of Rust Foundation Members visit https://rustfoundation.org/members/.
+
+### The RCN Steering Committee Consists Of
+
+* No more than seven and no less than five representatives from Platinum (1), Gold (1) , Silver (2), and Associate (1) Rust Foundation members. There cannot be two Steering Committee Members from one company.
+* The Rust Foundation will have a seat on the Steering Committee in an advisory capacity.
+* The Rust Project will have a seat on the Steering Committee in an advisory capacity.
+
+### Terms and Termination
+
+* RCN SC Members serve approximately two-year terms, with staggered terms initially.
+* RCN SC Membership ceases if a member resigns, is removed, or changes employment away from a Rust Foundation member. A super-majority vote can remove members not fulfilling their duties or complying with RCN policies.
+
+### Vacancies and Alternates
+
+* Vacancies that would put steering committee membership below five (5) are filled by election or invitation.
+
+### Eligibility and Criteria
+
+* Members must be employees of Rust Foundation Membership companies in good standing.
+* Only one representative from the same organization may serve at a time.

--- a/docs/meetings.md
+++ b/docs/meetings.md
@@ -1,0 +1,23 @@
+# RCN Meetings
+
+RCN meetings may cover sensitive adoption, production, or ecosystem concerns. To support candid discussion, the RCN may use Chatham House Rule. The RCN will host public monthly meeting(s)\* on Google Meet to discuss topics related to production Rust users.
+
+\*The RCN will determine the cadence and number of meetings per year.
+
+## Chatham House Rule
+
+[Chatham House Rule](https://www.chathamhouse.org/about-us/chatham-house-rule) means participants may share what was said, but may not identify who said it.
+
+When Chatham House Rule applies, participants may not record, transcribe, or use AI bots to capture the meeting.
+
+## Meeting Option
+
+If Chatham House Rule is not needed for a meeting, the RCN may allow recording or transcription with the group's agreement.
+
+## Notetaker Role
+
+Each meeting will have a notetaker from the Rust Foundation or the attendee group. See the [notetaker role](./notetaker-role.md) doc for more information.
+
+## Communication
+
+The RCN uses a channel in the [Rust Project Zulip](https://rust-lang.zulipchat.com/) for async discussion and meeting topics. Participants are encouraged to create public discussion threads when possible. Zulip is a public forum with members of the Rust Project, guests of the Project, end users, and Rust Foundation staff; threads are publicly accessible. Private channels may be necessary to discuss sensitive topics, but the preference is to keep conversations open, matching how the Project operates.

--- a/docs/membership.md
+++ b/docs/membership.md
@@ -1,0 +1,33 @@
+# RCN Membership
+
+Membership in the RCN is free.
+
+You do not need to work for a Rust Foundation member company to join discussions or propose work.
+
+## Member Definitions
+
+### Rust Foundation Member
+
+Individual representing a company that is a [member of the Rust Foundation](https://rustfoundation.org/members/) in good standing.
+
+### Commercial/Organizational Member
+
+A Commercial/Organizational Member is an individual who uses or evaluates Rust for work, including commercial, organizational, consulting, education, startup, small business, or independent professional work. These members may use Rust in production, contribute to Rust projects, or build Rust-based products or services.
+
+### Rust Advocate
+
+Rust Advocates are experienced Rust practitioners who work in areas such as Robotics, Automotive, Public Sector, and cloud native. These advocates have been sourced from participation in RustConf and other Rust Foundation initiatives. They may or may not be Rust Project members.
+
+### Rust Project Member
+
+Rust Project Members are individuals on a [Rust Team](https://rust-lang.org/governance/teams/) who make significant contributions to the development and maintenance of the Rust programming language and its associated tools.
+
+### Consortium/Working Group Member
+
+A Consortium/Working Group Member is an individual who is an active member of an RCN-affiliated consortium or working group, as determined by that group's own membership criteria and processes. Consortium/Working Group Members are recognized as RCN participants and may attend RCN meetings, contribute to discussions, and access RCN communication channels.
+
+Consortium/Working Group Members may vote on RCN matters that directly affect the consortium or working group in which they hold membership, including but not limited to: policies governing consortium operations, changes to the relationship between the RCN and its consortiums or working groups, and amendments to this charter that alter the rights or obligations of consortiums or working groups.
+
+Consortium/Working Group Members do not vote in RCN-wide elections such as Steering Committee seats unless they independently qualify under another RCN member definition.
+
+For the purposes of determining good standing, Consortium/Working Group Members must meet the membership requirements of their respective consortium or working group. Attendance at RCN-level meetings is not required for Consortium/Working Group Members to maintain good standing.

--- a/docs/working-groups.md
+++ b/docs/working-groups.md
@@ -1,0 +1,38 @@
+# RCN Consortiums and Working Groups
+
+RCN members can propose consortiums or working groups to the Steering Committee. These groups have a clear focus, report findings back to the Steering Committee, and follow the guidelines below.
+
+To propose a consortium or working group, [file an application using the GitHub Issue template](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=consortium-or-wg-proposal%2Cstatus%3A+needs+review&projects=&template=consortium_wg_proposal.yml).
+
+## Areas of Work
+
+RCN members may propose a consortium or working group for a specific Rust adoption or ecosystem maintenance topic. Proposed areas include:
+
+* Identifying shared challenges in Rust adoption, crate maintenance, supply chain reliability, and ecosystem maintenance
+* Creating high-level frameworks or templates to help others adopt Rust
+* Identifying basic tooling and library needs that affect production users
+* Highlighting projects that are not in the [Rust Innovation Lab (RIL)](https://rustfoundation.org/rust-innovation-lab/) but need more visibility, funding, or engineering time
+
+## Operations
+
+Each consortium and working group defines and administers its own membership criteria, tiers, and processes. Membership in an RCN consortium or working group does not necessarily require RCN membership.
+
+Membership in the RCN and membership in an RCN consortium or working group are independent. RCN membership does not confer membership, standing, or participation rights in any consortium or working group.
+
+## Steering Committee Scope
+
+The RCN Steering Committee reviews consortiums and working groups to make sure their work fits the RCN mission and is documented publicly. The SC does not have authority over a consortium's or working group's internal membership decisions, leadership selection, technical direction, or public communications.
+
+To be clear, "fits the RCN mission" means that the consortium or working group operates within the scope of Rust adoption by commercial, industrial, or organizational users. It does not authorize the SC to require changes to a consortium's or working group's scope, priorities, deliverables, publication schedule, or processes in order to remain affiliated with the RCN.
+
+## Voting Rights
+
+Only RCN members in good standing may vote in RCN-level elections, such as SC seats. Only consortium/working group members may vote in consortium/working group-level decisions, as defined by that group's own governance.
+
+## Existing Groups
+
+Consortiums and working groups that predate the RCN or that maintain their own governance structures retain full authority over their technical outputs, publication decisions, and operational processes. The SC may not condition continued RCN affiliation on changes to a consortium's existing governance, scope, processes, or external relationships, including direct relationships with the Rust Project, standards bodies, or other organizations.
+
+## Withdrawal
+
+An RCN-affiliated consortium or working group may withdraw from the RCN at any time by written notice from that group's leadership to the RCN Steering Committee. Upon withdrawal, the consortium or working group retains its existing governance structures, membership, repositories, branding, and intellectual property. Withdrawal does not require SC approval. Former RCN-affiliated groups are welcome to seek re-affiliation in the future.


### PR DESCRIPTION
Moving some of the process-heavy content out of our landing page README, into a subpage. Generally refactored it to be a bit more action oriented and targeted to readers that are considering joining.

Notably I now directly link the zulip channel, it is already public.