### PR TITLE
docs: add mdBook documentation site

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -1,0 +1,48 @@
+# https://rust-lang.github.io/mdBook/
+# Setup: enable GitHub Pages in repo Settings > Pages > Source: GitHub Actions
+name: Deploy mdBook
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    if: ${{ github.repository_owner == 'Rust-Commercial-Network' }}
+    runs-on: ubuntu-latest
+    env:
+      MDBOOK_VERSION: "0.4.40"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: Install mdBook
+        run: |
+          curl -sSL "https://github.com/rust-lang/mdBook/releases/download/v${MDBOOK_VERSION}/mdbook-v${MDBOOK_VERSION}-x86_64-unknown-linux-gnu.tar.gz" \
+            | tar -xz -C /usr/local/bin
+      - uses: actions/configure-pages@v5
+      - run: mdbook build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./book
+
+  deploy:
+    if: ${{ github.repository_owner == 'Rust-Commercial-Network' }}
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 # will have compiled files and executables
 debug/
 target/
+book/
 
 # Remove Cargo.lock from gitignore if creating an executable, leave it for libraries
 # More information here https://doc.rust-lang.org/cargo/guide/cargo-toml-vs-cargo-lock.html

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Rust Commercial Network (RCN)
 
+Read the full RCN guide and process docs in the [RCN mdBook](https://rust-commercial-network.github.io/rcn/).
+
 Where Rust users, businesses, and communities work together to make Rust easier to adopt and maintain.
 
 The Rust Commercial Network (RCN) is a Rust Foundation group for people and organizations using Rust in professional settings. Members compare notes on adoption blockers, improve Rust supply chain health, and support the basic tooling, libraries, and maintenance work that make Rust dependable in production.
@@ -8,74 +10,18 @@ The Rust Commercial Network (RCN) is a Rust Foundation group for people and orga
 
 **Discuss:** use the RCN channel in the [Rust Project Zulip](https://rust-lang.zulipchat.com/).
 
-## Overview
+## Process Docs
 
-The RCN is open to Rust users of all sizes: individual commercial users, consultants, startups, small businesses, larger companies, academic users, organizations, Rust Foundation Members, Rust Advocates, and members of the Rust Project. The RCN supports industry consortiums, interest groups, working groups, and other initiatives, with review from the RCN Steering Committee.
+* [Membership](docs/membership.md)
+* [Governance](docs/governance.md)
+* [Meetings](docs/meetings.md)
+* [Initiatives](docs/initiatives.md)
+* [Meeting notetaker role](docs/notetaker-role.md)
 
-The RCN is separate from the Rust Project’s developing [Rust Society](https://github.com/jamesmunns/rust-society/blob/main/reports/pdf/2025-04-04.pdf), although there may be some overlap over time.
+## Templates
 
-Membership in the RCN is free.
-
-The RCN works to:
-
-* Identify Rust adoption and maintenance problems shared by production users
-* Form consortiums, working groups, and interest groups around industry-specific or ecosystem-wide needs
-* Help members contribute time, funding, testing, documentation, and maintainer support
-* Share findings with the Rust Project, ecosystem maintainers, and the Rust Foundation
-
-## What Members Do
-
-* Meet regularly
-* Discuss topics that matter to production Rust users
-* Promote industry-specific adoption of Rust
-* Meet in person when possible, including at Rust Foundation events such as the Member Summit
-* Work with the Rust Project and ecosystem maintainers to identify and resolve issues that affect commercial and organizational use, including tooling gaps, crate reliability, maintenance bottlenecks, and adoption papercuts
-  * Members may contribute engineering time, funding, testing, maintainer support, documentation work, contributions to the Rust Foundation Maintainer’s Fund, or other help
-
-### RCN may produce:
-
-* Best practice guides and reference architectures
-* Adoption playbooks
-* Feedback summaries for the Rust Project
-* Gap analyses for tooling, libraries, documentation, and maintenance capacity
-* Prioritized lists of papercuts and reliability issues affecting production users
-* Recommendations to improve core tooling, widely used libraries, crate reliability, long-term maintenance, and Rust supply chain health
-
-\*Individual issues can be brought up to the Project independent of the RCN. The RCN aims to identify recurring or broadly shared issues, including smaller papercuts that add up to adoption, reliability, or maintenance problems across organizations.
-
-## RCN Initiatives: Interest Groups, Working Groups, and Consortiums
-
-RCN members can propose initiatives focused on shared adoption blockers, ecosystem maintenance, or industry-specific needs. These initiatives may be formally organized as interest groups, working groups, or consortiums which can produce guides, reports, recommendations, or other outputs for the Rust community.
-
-To propose an initiative, [file an application using the GitHub Issue template](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=initiative-proposal%2Cstatus%3A+needs+review&projects=&template=initiative_proposal.yml). See [RCN Initiatives: Interest Groups, Working Groups, and Consortiums](docs/initiatives.md) for operations, Steering Committee scope, voting rights, and withdrawal details.
-
-## Meetings and Communication
-
-The RCN hosts public monthly meeting(s)\* to discuss topics related to production Rust users. The meetings take place on Google Meet. The RCN may use Chatham House Rule when meetings cover sensitive topics.
-
-Public discussion happens in the RCN channel in the [Rust Project Zulip](https://rust-lang.zulipchat.com/). See [Meetings](docs/meetings.md) for meeting policy, note-taking, and communication details.
-
-\*The RCN will determine the cadence and number of meetings per year.
-
-## Member Definitions and Governance
-
-RCN membership is free. See [Membership](docs/membership.md) for member definitions, including Rust Foundation Members, Commercial/Organizational Members, Rust Advocates, Rust Project Members, and RCN Initiative Members.
-
-The Rust Foundation maintains the RCN with support from the RCN Steering Committee. See [Governance](docs/governance.md) for Steering Committee duties, composition, selection, terms, vacancies, and eligibility.
-
-## [Code of Conduct](https://foundation.rust-lang.org/policies/code-of-conduct/)
-
-The [Rust Foundation](https://rustfoundation.org/) has adopted a Code of Conduct that we expect RCN participants to adhere to. Please read [the full text](https://foundation.rust-lang.org/policies/code-of-conduct/) so that you can understand what actions will and will not be tolerated.
-
-## Community Events
-
-The Rust Foundation Member Summit, attached to RustConf, may provide one place for RCN members, Rust Foundation members, Rust Foundation Board Members, and Rust Project members to meet in person.
-
-## Next Steps
-
-* [Apply to join the RCN](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=membership%2Cstatus%3A+needs+review&projects=&template=membership.yml)
-* [Propose an initiative](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=initiative-proposal%2Cstatus%3A+needs+review&projects=&template=initiative_proposal.yml)
-* Join the RCN channel in the [Rust Project Zulip](https://rust-lang.zulipchat.com/)
+* [RCN meeting notes template](docs/rcn-meeting-notes-template.md)
+* [RCN initiative meeting notes template](docs/initiative-meeting-notes-template.md)
 
 ## Contributing
 
@@ -83,23 +29,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Licenses
 
-Rust is primarily distributed under the terms of both the MIT license and the
-Apache License (Version 2.0), with documentation portions covered by the
-Creative Commons Attribution 4.0 International license.
+Rust is primarily distributed under the terms of both the MIT license and the Apache License (Version 2.0), with documentation portions covered by the Creative Commons Attribution 4.0 International license.
 
-See [LICENSE-APACHE](LICENSE-APACHE), [LICENSE-MIT](LICENSE-MIT),
-[LICENSE-documentation](LICENSE-documentation), and
-[COPYRIGHT](COPYRIGHT) for details.
-
-You can also read more under the Foundation's [intellectual property
-policy][ip-policy].
-
-## Other Policies
-
-Members of the RCN must adhere to the Rust Foundation’s anti-trust policy [https://rustfoundation.org/policy/anti-trust-policy/](https://rustfoundation.org/policy/anti-trust-policy/) as you are a participant in the Foundation. Additional policies can be found on the [Rust Foundation website](https://rustfoundation.org/policies-resources/).
-
-[code-of-conduct]: https://rustfoundation.org/policy/code-of-conduct/
-[ip-policy]: https://rustfoundation.org/policy/intellectual-property-policy/
-[media-guide and trademark]: https://rustfoundation.org/policy/trademark-policy/
-[policies]: https://rustfoundation.org/policies-resources/
-[rust-foundation]: https://rustfoundation.org/
+See [LICENSE-APACHE](LICENSE-APACHE), [LICENSE-MIT](LICENSE-MIT), [LICENSE-documentation](LICENSE-documentation), and [COPYRIGHT](COPYRIGHT) for details.

--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -1,0 +1,16 @@
+# Summary
+
+- [Overview](./docs/overview.md)
+
+# Process
+
+- [Membership](./docs/membership.md)
+- [Governance](./docs/governance.md)
+- [Meetings](./docs/meetings.md)
+- [Initiatives](./docs/initiatives.md)
+- [Meeting Notetaker Role](./docs/notetaker-role.md)
+
+# Templates
+
+- [RCN Meeting Notes Template](./docs/rcn-meeting-notes-template.md)
+- [Initiative Meeting Notes Template](./docs/initiative-meeting-notes-template.md)

--- a/book.toml
+++ b/book.toml
@@ -1,0 +1,7 @@
+[book]
+title = "Rust Commercial Network"
+language = "en"
+src = "."
+
+[output.html]
+git-repository-url = "https://github.com/Rust-Commercial-Network/rcn"

--- a/docs/notetaker-role.md
+++ b/docs/notetaker-role.md
@@ -2,7 +2,7 @@
 
 Thank you for taking notes for a session! The following are the steps you will follow.
 
-Reminder that we follow the RCN-wide agreed meeting policies. Please refer to them in the [Meeting policies section of the README](../README.md#meetings).
+Reminder that we follow the RCN-wide agreed meeting policies. Please refer to the [Meetings](./meetings.md) doc.
 
 ## Take meeting notes live in a Google Docs document
 
@@ -25,11 +25,11 @@ Feel free to speak up during the meeting to clarify if something has risen to th
 
 ## Submit the meeting minutes to the repo
 
-Following the meeting you will select all the contents of the Google Doc, right click, and then click `Copy as Markdown` on the menu that pops up. You have to make sure Markdown is enabled for the document. Enabling it can be done by navigating to **Tools > Preferences** and checking **Enable Markdown**.
+Following the meeting you will select all the contents of the Google Doc, right click, and then click `Copy as Markdown` on the menu that pops up. You have to make sure Markdown is enabled for the document. Enable it from **Tools > Preferences** by checking **Enable Markdown**.
 
 Fork this repository if not done yet.
 
-Create a new branch on your fork, navigate to the `minutes.md` for the meeting you've taken minutes for and paste the contents.
+Create a new branch on your fork, open the `minutes.md` for the meeting you've taken minutes for, and paste the contents.
 
 ### Inserting annotation key
 

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,100 @@
+# Rust Commercial Network (RCN)
+
+Where Rust users, businesses, and communities work together to make Rust easier to adopt and maintain.
+
+The Rust Commercial Network (RCN) is a Rust Foundation group for people and organizations using Rust in professional settings. Members compare notes on adoption blockers, improve Rust supply chain health, and support the basic tooling, libraries, and maintenance work that make Rust dependable in production.
+
+**Join:** fill out the [membership application](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=membership%2Cstatus%3A+needs+review&projects=&template=membership.yml).
+
+**Discuss:** use the RCN channel in the [Rust Project Zulip](https://rust-lang.zulipchat.com/).
+
+## Overview
+
+The RCN is open to Rust users of all sizes: individual commercial users, consultants, startups, small businesses, larger companies, academic users, organizations, Rust Foundation Members, Rust Advocates, and members of the Rust Project. The RCN supports industry consortiums, interest groups, working groups, and other initiatives, with review from the RCN Steering Committee.
+
+The RCN is separate from the Rust Project's developing [Rust Society](https://github.com/jamesmunns/rust-society/blob/main/reports/pdf/2025-04-04.pdf), although there may be some overlap over time.
+
+Membership in the RCN is free.
+
+The RCN works to:
+
+* Identify Rust adoption and maintenance problems shared by production users
+* Form consortiums, working groups, and interest groups around industry-specific or ecosystem-wide needs
+* Help members contribute time, funding, testing, documentation, and maintainer support
+* Share findings with the Rust Project, ecosystem maintainers, and the Rust Foundation
+
+## What Members Do
+
+* Meet regularly
+* Discuss topics that matter to production Rust users
+* Promote industry-specific adoption of Rust
+* Meet in person when possible, including at Rust Foundation events such as the Member Summit
+* Work with the Rust Project and ecosystem maintainers to identify and resolve issues that affect commercial and organizational use, including tooling gaps, crate reliability, maintenance bottlenecks, and adoption papercuts
+  * Members may contribute engineering time, funding, testing, maintainer support, documentation work, contributions to the Rust Foundation Maintainer's Fund, or other help
+
+### RCN may produce:
+
+* Best practice guides and reference architectures
+* Adoption playbooks
+* Feedback summaries for the Rust Project
+* Gap analyses for tooling, libraries, documentation, and maintenance capacity
+* Prioritized lists of papercuts and reliability issues affecting production users
+* Recommendations to improve core tooling, widely used libraries, crate reliability, long-term maintenance, and Rust supply chain health
+
+\*Individual issues can be brought up to the Project independent of the RCN. The RCN aims to identify recurring or broadly shared issues, including smaller papercuts that add up to adoption, reliability, or maintenance problems across organizations.
+
+## RCN Initiatives: Interest Groups, Working Groups, and Consortiums
+
+RCN members can propose initiatives focused on shared adoption blockers, ecosystem maintenance, or industry-specific needs. These initiatives may be formally organized as interest groups, working groups, or consortiums which can produce guides, reports, recommendations, or other outputs for the Rust community.
+
+To propose an initiative, [file an application using the GitHub Issue template](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=initiative-proposal%2Cstatus%3A+needs+review&projects=&template=initiative_proposal.yml). See [RCN Initiatives: Interest Groups, Working Groups, and Consortiums](./initiatives.md) for operations, Steering Committee scope, voting rights, and withdrawal details.
+
+## Meetings and Communication
+
+The RCN hosts public monthly meeting(s)\* to discuss topics related to production Rust users. The meetings take place on Google Meet. The RCN may use Chatham House Rule when meetings cover sensitive topics.
+
+Public discussion happens in the RCN channel in the [Rust Project Zulip](https://rust-lang.zulipchat.com/). See [Meetings](./meetings.md) for meeting policy, note-taking, and communication details.
+
+\*The RCN will determine the cadence and number of meetings per year.
+
+## Member Definitions and Governance
+
+RCN membership is free. See [Membership](./membership.md) for member definitions, including Rust Foundation Members, Commercial/Organizational Members, Rust Advocates, Rust Project Members, and RCN Initiative Members.
+
+The Rust Foundation maintains the RCN with support from the RCN Steering Committee. See [Governance](./governance.md) for Steering Committee duties, composition, selection, terms, vacancies, and eligibility.
+
+## Code of Conduct
+
+The [Rust Foundation](https://rustfoundation.org/) has adopted a [Code of Conduct](https://foundation.rust-lang.org/policies/code-of-conduct/) that we expect RCN participants to adhere to. Please read the full text so that you can understand what actions will and will not be tolerated.
+
+## Community Events
+
+The Rust Foundation Member Summit, attached to RustConf, may provide one place for RCN members, Rust Foundation members, Rust Foundation Board Members, and Rust Project members to meet in person.
+
+## Next Steps
+
+* [Apply to join the RCN](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=membership%2Cstatus%3A+needs+review&projects=&template=membership.yml)
+* [Propose an initiative](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=initiative-proposal%2Cstatus%3A+needs+review&projects=&template=initiative_proposal.yml)
+* Join the RCN channel in the [Rust Project Zulip](https://rust-lang.zulipchat.com/)
+
+## Contributing
+
+See [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Licenses
+
+Rust is primarily distributed under the terms of both the MIT license and the Apache License (Version 2.0), with documentation portions covered by the Creative Commons Attribution 4.0 International license.
+
+See [LICENSE-APACHE](../LICENSE-APACHE), [LICENSE-MIT](../LICENSE-MIT), [LICENSE-documentation](../LICENSE-documentation), and [COPYRIGHT](../COPYRIGHT) for details.
+
+You can also read more under the Foundation's [intellectual property policy][ip-policy].
+
+## Other Policies
+
+Members of the RCN must adhere to the Rust Foundation's anti-trust policy [https://rustfoundation.org/policy/anti-trust-policy/](https://rustfoundation.org/policy/anti-trust-policy/) as you are a participant in the Foundation. Additional policies can be found on the [Rust Foundation website](https://rustfoundation.org/policies-resources/).
+
+[code-of-conduct]: https://rustfoundation.org/policy/code-of-conduct/
+[ip-policy]: https://rustfoundation.org/policy/intellectual-property-policy/
+[media-guide and trademark]: https://rustfoundation.org/policy/trademark-policy/
+[policies]: https://rustfoundation.org/policies-resources/
+[rust-foundation]: https://rustfoundation.org/

--- a/docs/rcn-meeting-notes-template.md
+++ b/docs/rcn-meeting-notes-template.md
@@ -14,13 +14,13 @@
 
 **Please add your name, and an emoji that describes your day.**
 
-* 
+*
 
 **Notetaker:**
 
 * 
 
-For tips on how we take notes in the Safety-Critical Rust Consortium, please see the [Meeting Notetaker Role](https://github.com/Rust-Commercial-Network/rcn/blob/main/docs/notetaker-role.md) doc.
+For tips on how we take notes in the RCN, please see the [Meeting Notetaker Role](https://github.com/Rust-Commercial-Network/rcn/blob/main/docs/notetaker-role.md) doc.
 
 ## Housekeeping section
 
@@ -38,4 +38,4 @@ For tips on how we take notes in the Safety-Critical Rust Consortium, please see
 
 Any material to read before the meeting should be included here.
 
-* 
+*


### PR DESCRIPTION
Starting a mdbook based on our existing content. We are preparing a "call for funding partners" page as well, which will follow.

I considered docusaurus per [this discussion](https://github.com/Rust-Commercial-Network/rcn/pull/36#issuecomment-4676219872) but it was much heavier weight than we needed for a github action, and there was clearer prior art in rust repos for mdbook. We can always change later if our site matures.