### PR TITLE
Add cargo-semver-checks to funding directory

### DIFF
--- a/docs/funding-directory.md
+++ b/docs/funding-directory.md
@@ -74,11 +74,9 @@ Related: [cargo-nextest](https://nexte.st/).
 
 ### cargo-semver-checks
 
-`cargo-semver-checks` is a Semantic Versioning (SemVer) linter for Rust. Its goal is to make `cargo update` and `cargo publish` fearless, allowing maintainers to publish new releases without accidentally shipping breaking changes. In turn, this allows users to fearlessly update their dependency versions without having their projects broken by accidental upstream breakage.
+`cargo-semver-checks` helps Rust maintainers catch accidental SemVer breakage before publishing releases. This is especially useful for SDKs and libraries where breaking changes can disrupt downstream customers and make dependency upgrades risky.
 
-RCN members may find `cargo-semver-checks` most useful when publishing SDKs intended for customer use. [Accidental breakage is common](https://predr.ag/blog/semver-violations-are-common-better-tooling-is-the-answer/) and frustrates paying customers of such SDKs; `cargo-semver-checks` helps prevent such incidents, giving both maintainers and users confidence that version upgrades will "just work."
-
-Despite its usefulness, the coverage `cargo-semver-checks` offers has material gaps and points of friction that funding would help address. SemVer lints currently cannot catch type-related breakage like changing a pub field from `i64` to `String`, and cannot perform cross-crate analysis causing any items re-exported across crate boundaries to not be checked. This leads to both false-positives and false-negatives. Additionally, the current `cargo-semver-checks` developer experience is not friendly toward PR-based workflows: it's difficult to use the tool to flag breaking changes that are newly made in that PR, versus ones made in prior PRs that were merged after the most-recently published version.
+Funding would support work to close major coverage gaps and improve PR-based workflows. Current limitations include missing type-related breaking changes, missing cross-crate analysis for re-exports, and difficulty distinguishing breakage introduced by a new PR from breakage that already exists since the last published release.
 
 Related:
 - [cargo-semver-checks][cargo-semver-checks]

--- a/docs/funding-directory.md
+++ b/docs/funding-directory.md
@@ -72,6 +72,20 @@ Funding would buy down unpaid maintenance work for [Rain (@sunshowers)](https://
 
 Related: [cargo-nextest](https://nexte.st/).
 
+### cargo-semver-checks
+
+`cargo-semver-checks` is a Semantic Versioning (SemVer) linter for Rust. Its goal is to make `cargo update` and `cargo publish` fearless, allowing maintainers to publish new releases without accidentally shipping breaking changes. In turn, this allows users to fearlessly update their dependency versions without having their projects broken by accidental upstream breakage.
+
+RCN members may find `cargo-semver-checks` most useful when publishing SDKs intended for customer use. [Accidental breakage is common](https://predr.ag/blog/semver-violations-are-common-better-tooling-is-the-answer/) and frustrates paying customers of such SDKs; `cargo-semver-checks` helps prevent such incidents, giving both maintainers and users confidence that version upgrades will "just work."
+
+Despite its usefulness, the coverage `cargo-semver-checks` offers has material gaps and points of friction that funding would help address. SemVer lints currently cannot catch type-related breakage like changing a pub field from `i64` to `String`, and cannot perform cross-crate analysis causing any items re-exported across crate boundaries to not be checked. This leads to both false-positives and false-negatives. Additionally, the current `cargo-semver-checks` developer experience is not friendly toward PR-based workflows: it's difficult to use the tool to flag breaking changes that are newly made in that PR, versus ones made in prior PRs that were merged after the most-recently published version.
+
+Related:
+- [cargo-semver-checks][cargo-semver-checks]
+- [roadmap](https://predr.ag/blog/cargo-semver-checks-2025-year-in-review/#the-path-forward-for-2026-and-beyond)
+- [project goal][cargo-semver-checks-goal]
+- [goal tracking issue][cargo-semver-checks-goal-tracking]
+
 ### Cargo Maintenance
 
 Many Rust roadmap items need Cargo review or implementation work, including work on supply-chain policy, build reproducibility, C++ interoperability, signed crates, and sandboxed build scripts. This item funds general Cargo review and implementation time, not reserved reviewer time for funder-requested changes.
@@ -192,6 +206,9 @@ To discuss funding, procurement, or private production feedback, contact [rust-c
 [async-state-machine-goal]: https://rust-lang.github.io/rust-project-goals/2026/async-statemachine-optimisation.html#funding
 [bjorn3]: https://github.com/bjorn3
 [cargo]: https://github.com/rust-lang/cargo
+[cargo-semver-checks]: https://github.com/obi1kenobi/cargo-semver-checks
+[cargo-semver-checks-goal]: https://rust-lang.github.io/rust-project-goals/2026/cargo-semver-checks.html
+[cargo-semver-checks-goal-tracking]: https://github.com/rust-lang/rust-project-goals/issues/104
 [cargo-cross-workspace-cache]: https://rust-lang.github.io/rust-project-goals/2026/cargo-cross-workspace-cache.html
 [cranelift]: https://github.com/bytecodealliance/wasmtime/tree/main/cranelift
 [cranelift-performance]: https://rust-lang.github.io/rust-project-goals/2026/improve-cg_clif-performance.html


### PR DESCRIPTION
Possible conflict of interest disclosure: I wear many hats in the Rust community. I am submitting this in an individual capacity as a Rust Project member and maintainer of `cargo-semver-checks`. Separately, I am also employed by OpenAI and am a member of the Rust Foundation board, though my contributions to the Rust Project thus far have not been under those roles.

My employer is not funding `cargo-semver-checks`. None of the funding my employer is committing for funding Rust will benefit `cargo-semver-checks`, either directly or indirectly.

I will proactively recuse myself from any discussion of funding `cargo-semver-checks` development, including for the avoidance of doubt any hypothetical discussion of allocation of open-ended funding between different initiatives under the RCN umbrella.

I will aim to hold myself to "not even appearance of impropriety" as the appropriate standard of behavior here. I have a full-time job that will pay my bills — I'm not building `cargo-semver-checks` for the money, and any funding will merely motivate me to spend more nights and weekends coding for it rather than pursuing other things. If there is ever any substantive question about whether I've held myself to that standard, I hereby commit to act as directed by the RCN steering committee and T-funding to remedy the situation, up to and including donating received funds back to other goals and programs duly selected by those teams.

If there are any additional terms the RCN steering committee or T-funding would propose or deem appropriate here, I welcome suggestions. If either the RCN steering committee or T-funding believe the possible conflicts of interest cannot be avoided by the addition of any terms, I proactively agree they may withdraw `cargo-semver-checks` from the funding directory without requiring any consent or notification to me.