### PR TITLE
feat: member list validation, email masking

### DIFF
--- a/.github/ISSUE_TEMPLATE/membership.yml
+++ b/.github/ISSUE_TEMPLATE/membership.yml
@@ -14,7 +14,7 @@ body:
 
         Membership in the RCN is free.
 
-        > Note that the name, email address, and any company you provide will be public since GitHub issues are public. We do not use your information for any reason other than for membership purposes.
+        > Note that your name, email address, and any company or organization you provide will be visible on this public GitHub issue when submitted. If your application is approved, the issue body email address will be masked when the issue is closed, but it may still appear in GitHub notifications, history, or other places outside this repository. We do not use your information for any reason other than for membership purposes.
   - type: input
     id: Name
     attributes:

--- a/.github/ISSUE_TEMPLATE/membership.yml
+++ b/.github/ISSUE_TEMPLATE/membership.yml
@@ -47,15 +47,15 @@ body:
     id: entity-name
     attributes:
       label: If you represent a company, institution, consortium, or other entity, please enter it here. If you represent the Rust Project, please enter the Rust Project team.
-      description: If you are representing other than yourself, please enter it. Otherwise, type 'Individual'.
-      placeholder: Type company, Rust Project Team, or entity name, or type "Individual" 
+      description: "Enter only the short public name for the member directory. Do not include background information, websites, email addresses, or explanations here. Put that context in the \"Why are you interested in joining the RCN?\" answer below. If you are representing only yourself, type 'Individual'."
+      placeholder: "Example: Acme Corp, Rust Project Team, or Individual"
     validations:
       required: true
   - type: textarea
     id: why-interested
     attributes:
       label: Why are you interested in joining the RCN?
-      description: If applicable, describe work that you are doing or planning to do in the rcn.
+      description: "If applicable, describe work that you are doing or planning to do in the RCN. You may include background information about your company or organization, relevant websites, or other context here."
     validations:
       required: true
   - type: dropdown

--- a/.github/workflows/membership-approved.yml
+++ b/.github/workflows/membership-approved.yml
@@ -183,77 +183,6 @@ jobs:
 
             core.info('Entity name is valid for the public member directory.');
 
-      - name: Mask public email address
-        uses: actions/github-script@v7
-        env:
-          FIELD_EMAIL: ${{ steps.parse.outputs.email }}
-        with:
-          script: |
-            const email = process.env.FIELD_EMAIL || '';
-
-            function maskEmail(email) {
-              const atIndex = email.indexOf('@');
-              if (atIndex <= 0 || atIndex !== email.lastIndexOf('@') || atIndex === email.length - 1) {
-                return email;
-              }
-
-              function maskPart(part) {
-                if (part.length === 1) {
-                  return `${part}**`;
-                }
-                return `${part[0]}**${part[part.length - 1]}`;
-              }
-
-              const local = email.slice(0, atIndex);
-              const domain = email.slice(atIndex + 1);
-              return `${maskPart(local)}@${maskPart(domain)}`;
-            }
-
-            function replaceField(body, heading, value) {
-              const sections = body.split(/^###\s*/m);
-              let replaced = false;
-
-              for (let i = 1; i < sections.length; i += 1) {
-                if (sections[i].startsWith(heading)) {
-                  sections[i] = `${heading}\n\n${value}\n\n`;
-                  replaced = true;
-                  break;
-                }
-              }
-
-              if (!replaced) {
-                return null;
-              }
-
-              return `${sections[0]}${sections.slice(1).map((section) => `### ${section}`).join('')}`;
-            }
-
-            const maskedEmail = maskEmail(email);
-            if (!email || maskedEmail === email) {
-              core.info('No public email masking update needed.');
-              return;
-            }
-
-            const updatedBody = replaceField(
-              context.payload.issue.body || '',
-              'What is your preferred email address?',
-              maskedEmail,
-            );
-
-            if (!updatedBody) {
-              core.warning('Could not find the email field in the issue body.');
-              return;
-            }
-
-            await github.rest.issues.update({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: updatedBody,
-            });
-
-            core.info('Masked the public email address in the issue body.');
-
       - name: Add issue to GitHub Project
         id: add-to-project
         uses: actions/add-to-project@v1.0.2
@@ -393,3 +322,82 @@ jobs:
             }
 
             core.info('All fields populated successfully.');
+
+      - name: Mask public email address
+        uses: actions/github-script@v7
+        env:
+          FIELD_EMAIL: ${{ steps.parse.outputs.email }}
+        with:
+          script: |
+            const email = process.env.FIELD_EMAIL || '';
+
+            function maskPart(part) {
+              if (part.length === 1) {
+                return `${part}**`;
+              }
+              return `${part[0]}**${part[part.length - 1]}`;
+            }
+
+            function maskEmail(email) {
+              const atIndex = email.indexOf('@');
+              if (atIndex <= 0 || atIndex !== email.lastIndexOf('@') || atIndex === email.length - 1) {
+                return email;
+              }
+
+              const local = email.slice(0, atIndex);
+              const domain = email.slice(atIndex + 1);
+              const dotIndex = domain.indexOf('.');
+
+              if (dotIndex <= 0) {
+                return `${maskPart(local)}@${maskPart(domain)}`;
+              }
+
+              const domainName = domain.slice(0, dotIndex);
+              const domainSuffix = domain.slice(dotIndex);
+              return `${maskPart(local)}@${maskPart(domainName)}${domainSuffix}`;
+            }
+
+            function replaceField(body, heading, value) {
+              const sections = body.split(/^###\s*/m);
+              let replaced = false;
+
+              for (let i = 1; i < sections.length; i += 1) {
+                if (sections[i].startsWith(heading)) {
+                  sections[i] = `${heading}\n\n${value}\n\n`;
+                  replaced = true;
+                  break;
+                }
+              }
+
+              if (!replaced) {
+                return null;
+              }
+
+              return `${sections[0]}${sections.slice(1).map((section) => `### ${section}`).join('')}`;
+            }
+
+            const maskedEmail = maskEmail(email);
+            if (!email || maskedEmail === email) {
+              core.info('No public email masking update needed.');
+              return;
+            }
+
+            const updatedBody = replaceField(
+              context.payload.issue.body || '',
+              'What is your preferred email address?',
+              maskedEmail,
+            );
+
+            if (!updatedBody) {
+              core.warning('Could not find the email field in the issue body.');
+              return;
+            }
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: updatedBody,
+            });
+
+            core.info('Masked the public email address in the issue body.');

--- a/.github/workflows/membership-approved.yml
+++ b/.github/workflows/membership-approved.yml
@@ -38,9 +38,17 @@ jobs:
               body,
               'If you represent a company, institution, consortium, or other entity, please enter it here. If you represent the Rust Project, please enter the Rust Project team.',
             );
+            const normalizedEntityName = entityName.trim().toLowerCase();
+            let validationError = '';
 
-            if (entityName.length <= maxEntityLength) {
-              core.info(`Entity name length is ${entityName.length}, within the ${maxEntityLength} character limit.`);
+            if (entityName.length > maxEntityLength) {
+              validationError = `the Entity answer is ${entityName.length} characters, which is longer than the ${maxEntityLength} character limit used for the public member directory`;
+            } else if (normalizedEntityName === 'company') {
+              validationError = 'the Entity answer is `Company`, which is too generic for the public member directory';
+            }
+
+            if (!validationError) {
+              core.info('Entity name is valid for the public member directory.');
               return;
             }
 
@@ -49,7 +57,7 @@ jobs:
               repo: context.repo.repo,
               issue_number: context.issue.number,
               body: [
-                `@${context.payload.sender.login}, the Entity answer is ${entityName.length} characters, which is longer than the ${maxEntityLength} character limit used for the public member directory.`,
+                `@${context.payload.sender.login}, ${validationError}.`,
                 '',
                 'Please edit the membership issue body so the Entity answer is the short public directory name, then re-apply `membership-approved`.',
               ].join('\n'),
@@ -69,7 +77,7 @@ jobs:
               core.info('membership-approved label was already removed.');
             }
 
-            core.setFailed(`Entity answer is ${entityName.length} characters. Limit is ${maxEntityLength}.`);
+            core.setFailed(validationError);
 
   add-to-project:
     # Only run when the issue is closed by an assignee or repo admin,
@@ -161,13 +169,19 @@ jobs:
           script: |
             const maxEntityLength = 80;
             const entityName = process.env.FIELD_ENTITY_NAME || '';
+            const normalizedEntityName = entityName.trim().toLowerCase();
 
             if (entityName.length > maxEntityLength) {
               core.setFailed(`Entity answer is ${entityName.length} characters. Limit is ${maxEntityLength}. Edit the membership issue body before closing.`);
               return;
             }
 
-            core.info(`Entity name length is ${entityName.length}, within the ${maxEntityLength} character limit.`);
+            if (normalizedEntityName === 'company') {
+              core.setFailed('Entity answer is `Company`, which is too generic for the public member directory. Edit the membership issue body before closing.');
+              return;
+            }
+
+            core.info('Entity name is valid for the public member directory.');
 
       - name: Mask public email address
         uses: actions/github-script@v7

--- a/.github/workflows/membership-approved.yml
+++ b/.github/workflows/membership-approved.yml
@@ -2,18 +2,85 @@ name: Add Approved Member to Membership Project Board
 
 on:
   issues:
-    types: [closed]
+    types: [closed, labeled]
 
 jobs:
+  validate-membership-approval:
+    # Run as soon as a maintainer applies the approval label so directory data can
+    # be cleaned up before the issue is closed and copied into the project.
+    if: >-
+      github.event.action == 'labeled' &&
+      github.event.label.name == 'membership-approved' &&
+      contains(toJSON(github.event.issue.labels.*.name), 'membership')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+
+    steps:
+      - name: Validate public entity name
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const maxEntityLength = 80;
+            const body = context.payload.issue.body || '';
+
+            function extractField(body, heading) {
+              const sections = body.split(/^###\s*/m);
+              for (const section of sections) {
+                if (section.startsWith(heading)) {
+                  return section.slice(heading.length).trim();
+                }
+              }
+              return '';
+            }
+
+            const entityName = extractField(
+              body,
+              'If you represent a company, institution, consortium, or other entity, please enter it here. If you represent the Rust Project, please enter the Rust Project team.',
+            );
+
+            if (entityName.length <= maxEntityLength) {
+              core.info(`Entity name length is ${entityName.length}, within the ${maxEntityLength} character limit.`);
+              return;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: [
+                `@${context.payload.sender.login}, the Entity answer is ${entityName.length} characters, which is longer than the ${maxEntityLength} character limit used for the public member directory.`,
+                '',
+                'Please edit the membership issue body so the Entity answer is the short public directory name, then re-apply `membership-approved`.',
+              ].join('\n'),
+            });
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'membership-approved',
+              });
+            } catch (error) {
+              if (error.status !== 404) {
+                throw error;
+              }
+              core.info('membership-approved label was already removed.');
+            }
+
+            core.setFailed(`Entity answer is ${entityName.length} characters. Limit is ${maxEntityLength}.`);
+
   add-to-project:
     # Only run when the issue is closed by an assignee or repo admin,
     # and has both 'membership' and 'membership-approved' labels
     if: >-
+      github.event.action == 'closed' &&
       contains(toJSON(github.event.issue.labels.*.name), 'membership') &&
       contains(toJSON(github.event.issue.labels.*.name), 'membership-approved')
     runs-on: ubuntu-latest
     permissions:
-      issues: read
+      issues: write
 
     steps:
       - name: Verify sender is assignee or admin
@@ -85,6 +152,93 @@ jobs:
             core.setOutput('foundation_member', foundationMember);
 
             core.info(`Parsed — GitHub ID: ${githubId}, Name: ${name}, Email: ${email}, Representation: ${representation}, Entity: ${entityName}`);
+
+      - name: Check public entity name length
+        uses: actions/github-script@v7
+        env:
+          FIELD_ENTITY_NAME: ${{ steps.parse.outputs.entity_name }}
+        with:
+          script: |
+            const maxEntityLength = 80;
+            const entityName = process.env.FIELD_ENTITY_NAME || '';
+
+            if (entityName.length > maxEntityLength) {
+              core.setFailed(`Entity answer is ${entityName.length} characters. Limit is ${maxEntityLength}. Edit the membership issue body before closing.`);
+              return;
+            }
+
+            core.info(`Entity name length is ${entityName.length}, within the ${maxEntityLength} character limit.`);
+
+      - name: Mask public email address
+        uses: actions/github-script@v7
+        env:
+          FIELD_EMAIL: ${{ steps.parse.outputs.email }}
+        with:
+          script: |
+            const email = process.env.FIELD_EMAIL || '';
+
+            function maskEmail(email) {
+              const atIndex = email.indexOf('@');
+              if (atIndex <= 0 || atIndex !== email.lastIndexOf('@') || atIndex === email.length - 1) {
+                return email;
+              }
+
+              function maskPart(part) {
+                if (part.length === 1) {
+                  return `${part}**`;
+                }
+                return `${part[0]}**${part[part.length - 1]}`;
+              }
+
+              const local = email.slice(0, atIndex);
+              const domain = email.slice(atIndex + 1);
+              return `${maskPart(local)}@${maskPart(domain)}`;
+            }
+
+            function replaceField(body, heading, value) {
+              const sections = body.split(/^###\s*/m);
+              let replaced = false;
+
+              for (let i = 1; i < sections.length; i += 1) {
+                if (sections[i].startsWith(heading)) {
+                  sections[i] = `${heading}\n\n${value}\n\n`;
+                  replaced = true;
+                  break;
+                }
+              }
+
+              if (!replaced) {
+                return null;
+              }
+
+              return `${sections[0]}${sections.slice(1).map((section) => `### ${section}`).join('')}`;
+            }
+
+            const maskedEmail = maskEmail(email);
+            if (!email || maskedEmail === email) {
+              core.info('No public email masking update needed.');
+              return;
+            }
+
+            const updatedBody = replaceField(
+              context.payload.issue.body || '',
+              'What is your preferred email address?',
+              maskedEmail,
+            );
+
+            if (!updatedBody) {
+              core.warning('Could not find the email field in the issue body.');
+              return;
+            }
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: updatedBody,
+            });
+
+            core.info('Masked the public email address in the issue body.');
 
       - name: Add issue to GitHub Project
         id: add-to-project

--- a/.github/workflows/membership-approved.yml
+++ b/.github/workflows/membership-approved.yml
@@ -333,9 +333,9 @@ jobs:
 
             function maskPart(part) {
               if (part.length === 1) {
-                return `${part}**`;
+                return `${part}∗∗`;
               }
-              return `${part[0]}**${part[part.length - 1]}`;
+              return `${part[0]}∗∗${part[part.length - 1]}`;
             }
 
             function maskEmail(email) {
@@ -357,23 +357,38 @@ jobs:
               return `${maskPart(local)}@${maskPart(domainName)}${domainSuffix}`;
             }
 
-            function replaceField(body, heading, value) {
-              const sections = body.split(/^###\s*/m);
-              let replaced = false;
-
-              for (let i = 1; i < sections.length; i += 1) {
-                if (sections[i].startsWith(heading)) {
-                  sections[i] = `${heading}\n\n${value}\n\n`;
-                  replaced = true;
-                  break;
-                }
-              }
-
-              if (!replaced) {
+            function findFieldValueRange(body, heading) {
+              const headingText = `### ${heading}`;
+              const headingStart = body.indexOf(headingText);
+              if (headingStart === -1) {
                 return null;
               }
 
-              return `${sections[0]}${sections.slice(1).map((section) => `### ${section}`).join('')}`;
+              const valueStartSearch = headingStart + headingText.length;
+              const nextHeadingMatch = /^###\s/m.exec(body.slice(valueStartSearch));
+              const sectionEnd = nextHeadingMatch ? valueStartSearch + nextHeadingMatch.index : body.length;
+              const sectionValue = body.slice(valueStartSearch, sectionEnd);
+              const leadingWhitespace = sectionValue.match(/^\s*/)[0].length;
+              const trailingWhitespace = sectionValue.match(/\s*$/)[0].length;
+
+              return {
+                start: valueStartSearch + leadingWhitespace,
+                end: sectionEnd - trailingWhitespace,
+              };
+            }
+
+            function replaceFieldValue(body, heading, oldValue, newValue) {
+              const range = findFieldValueRange(body, heading);
+              if (!range) {
+                return null;
+              }
+
+              const currentValue = body.slice(range.start, range.end);
+              if (currentValue.trim() !== oldValue) {
+                return null;
+              }
+
+              return `${body.slice(0, range.start)}${newValue}${body.slice(range.end)}`;
             }
 
             const maskedEmail = maskEmail(email);
@@ -382,9 +397,10 @@ jobs:
               return;
             }
 
-            const updatedBody = replaceField(
+            const updatedBody = replaceFieldValue(
               context.payload.issue.body || '',
               'What is your preferred email address?',
+              email,
               maskedEmail,
             );
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,27 +34,19 @@ the `Issues` tab.
 
 ### Membership Approvals
 
-Membership applications are filed as public GitHub issues using the membership
-issue form. When reviewing an application, confirm that the applicant's answers
-are complete and suitable for the public membership directory before marking the
-issue approved.
+Membership applications are public GitHub issues. The issue body is the source
+for the membership project fields and generated member directory.
 
-The `membership-approved` label marks an application as approved. After that
-label is applied, closing the issue copies the application into the membership
-project and populates the project fields used by the generated member
-directory. When the approved issue is closed, the workflow also masks the email
-address in the public issue body.
+Before applying `membership-approved`, edit the issue body if any public
+directory value needs cleanup. Pay special attention to Entity: it becomes the
+public company, organization, team, or individual name. Use a short name, not a
+sentence, explanation, website URL, email address, or generic value such as
+`Company`. Move context into the "Why are you interested in joining the RCN?"
+answer.
 
-Before applying `membership-approved`, review the answer to the Entity question.
-This value becomes the public company, organization, team, or individual name in
-the member directory. Use a short public directory name rather than a sentence,
-explanation, website URL, or email address. Do not leave a generic value such as
-`Company`. Move context or explanation into the "Why are you interested in
-joining the RCN?" answer.
-
-The approval workflow removes `membership-approved` and comments on the issue if
-the Entity answer is longer than 80 characters or is only `Company`. After
-editing the issue body, apply `membership-approved` again and close the issue.
+After the issue body is ready, apply `membership-approved` and close the issue.
+Closing an approved issue copies the issue body into the membership project and
+masks the email address in the public issue body.
 
 [ip-policy]: https://foundation.rust-lang.org/policies/intellectual-property-policy/
 [pull-requests]: https://help.github.com/articles/about-pull-requests/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,9 +47,10 @@ address in the public issue body.
 
 Before applying `membership-approved`, review the answer to the Entity question.
 This value becomes the public company, organization, team, or individual name in
-the member directory. Use a short public directory name rather than a sentence
+the member directory. Use a short public directory name rather than a sentence,
 explanation, website URL, or email address. Do not leave a generic value such as
-`Company`.
+`Company`. Move context or explanation into the "Why are you interested in
+joining the RCN?" answer.
 
 The approval workflow removes `membership-approved` and comments on the issue if
 the Entity answer is longer than 80 characters or is only `Company`. After

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,5 +30,29 @@ for more information on using pull requests.
 Do you just want to file an issue for the project? Please do so in GitHub under 
 the `Issues` tab.
 
+## Internal Contributors
+
+### Membership Approvals
+
+Membership applications are filed as public GitHub issues using the membership
+issue form. When reviewing an application, confirm that the applicant's answers
+are complete and suitable for the public membership directory before marking the
+issue approved.
+
+The `membership-approved` label marks an application as approved. After that
+label is applied, closing the issue copies the application into the membership
+project and populates the project fields used by the generated member
+directory. When the approved issue is closed, the workflow also masks the email
+address in the public issue body.
+
+Before applying `membership-approved`, review the answer to the Entity question.
+This value becomes the public company, organization, team, or individual name in
+the member directory. Use a short public directory name rather than a sentence
+or explanation.
+
+The approval workflow removes `membership-approved` and comments on the issue if
+the Entity answer is longer than 80 characters. After editing the issue body,
+apply `membership-approved` again and close the issue.
+
 [ip-policy]: https://foundation.rust-lang.org/policies/intellectual-property-policy/
 [pull-requests]: https://help.github.com/articles/about-pull-requests/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,8 @@ address in the public issue body.
 Before applying `membership-approved`, review the answer to the Entity question.
 This value becomes the public company, organization, team, or individual name in
 the member directory. Use a short public directory name rather than a sentence
-or explanation. Do not leave a generic value such as `Company`.
+explanation, website URL, or email address. Do not leave a generic value such as
+`Company`.
 
 The approval workflow removes `membership-approved` and comments on the issue if
 the Entity answer is longer than 80 characters or is only `Company`. After

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,11 +48,11 @@ address in the public issue body.
 Before applying `membership-approved`, review the answer to the Entity question.
 This value becomes the public company, organization, team, or individual name in
 the member directory. Use a short public directory name rather than a sentence
-or explanation.
+or explanation. Do not leave a generic value such as `Company`.
 
 The approval workflow removes `membership-approved` and comments on the issue if
-the Entity answer is longer than 80 characters. After editing the issue body,
-apply `membership-approved` again and close the issue.
+the Entity answer is longer than 80 characters or is only `Company`. After
+editing the issue body, apply `membership-approved` again and close the issue.
 
 [ip-policy]: https://foundation.rust-lang.org/policies/intellectual-property-policy/
 [pull-requests]: https://help.github.com/articles/about-pull-requests/


### PR DESCRIPTION
Follow-up to: https://github.com/Rust-Commercial-Network/rcn/issues/89#issuecomment-4825388794

Adding a guard when the membership label is added to check for a super-long entity name, in which case it removes the `membership-approved` label and leaves a comment tagging the person that added the label warning them to edit the entity name. Also checks for literally "Company", i fixed one of those too. That keeps our directory clean.

Sadly, github issue forms don't support validation on length or regex, which would have been simpler.

While I was at it, adding a behavior to mask the email in the github issue as they are added to the project so we don't cause people to get spammed. I went ahead and bulk masked all the existing ones as well. There still would be a window where their email is visible publicly before their membership is merged, but GitHub does have its own anti-bot stuff as well that does hopefully *something*.

Lastly, I tweaked the form's hints to push people in the right direction a bit more.