### PR TITLE
docs: clean up mdbook organization and contents

### DIFF
--- a/.github/scripts/generate-members.mjs
+++ b/.github/scripts/generate-members.mjs
@@ -265,7 +265,7 @@ async function addSummaryEntry() {
     throw new Error(`Could not add member list to ${summaryPath}: overview entry not found.`);
   }
 
-  const updated = summary.replace(overviewEntry, `${overviewEntry}- [Members](./members.md)\n`);
+  const updated = summary.replace(overviewEntry, `${overviewEntry}- [Member Directory](./members.md)\n`);
   await fs.writeFile(summaryPath, updated);
 }
 

--- a/README.md
+++ b/README.md
@@ -12,16 +12,15 @@ The Rust Commercial Network (RCN) is a Rust Foundation group for people and orga
 
 **Discuss:** use the RCN channel in the [Rust Project Zulip](https://rust-lang.zulipchat.com/).
 
-**Support Rust ecosystem work:** see the [Funding Directory](docs/funding-directory.md).
+**Support Rust ecosystem work:** see the [Funding Directory](https://rust-commercial-network.github.io/rcn/funding-directory.html).
 
 ## Process Docs
 
 * [Membership](docs/membership.md)
 * [Governance](docs/governance.md)
-* [Conflict of Interest Policy](CONFLICT_OF_INTEREST_POLICY.md)
+* [Conflict of Interest Policy](docs/conflict-of-interest-policy.md)
 * [Meetings](docs/meetings.md)
 * [Initiatives](docs/initiatives.md)
-* [Funding Directory](docs/funding-directory.md)
 * [Meeting notetaker role](docs/notetaker-role.md)
 
 ## Templates
@@ -32,9 +31,3 @@ The Rust Commercial Network (RCN) is a Rust Foundation group for people and orga
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).
-
-## Licenses
-
-Rust is primarily distributed under the terms of both the MIT license and the Apache License (Version 2.0), with documentation portions covered by the Creative Commons Attribution 4.0 International license.
-
-See [LICENSE-APACHE](LICENSE-APACHE), [LICENSE-MIT](LICENSE-MIT), [LICENSE-documentation](LICENSE-documentation), and [COPYRIGHT](COPYRIGHT) for details.

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -1,6 +1,8 @@
 # Summary
 
 - [Overview](./overview.md)
+- [Member Directory](./members.md)
+- [Funding Directory](./funding-directory.md)
 
 # Process
 
@@ -9,7 +11,6 @@
 - [Conflict of Interest Policy](./conflict-of-interest-policy.md)
 - [Meetings](./meetings.md)
 - [Initiatives](./initiatives.md)
-- [Funding Directory](./funding-directory.md)
 - [Meeting Notetaker Role](./notetaker-role.md)
 
 # Templates

--- a/docs/initiative-meeting-notes-template.md
+++ b/docs/initiative-meeting-notes-template.md
@@ -1,3 +1,4 @@
+```markdown
 # \<Foo\> RCN Initiative Meeting on \<date\> @ \<time\>
 
 | Search Key | Description |
@@ -8,34 +9,35 @@
 
 ## Agenda
 
-1. 
+1.
 
 ## Check-in area
 
 **Please add your name, and an emoji that describes your day.**
 
-* 
+*
 
 **Notetaker:**
 
-* 
+*
 
 For tips on how we take notes in the RCN, please see the [Meeting Notetaker Role](https://github.com/Rust-Commercial-Network/rcn/blob/main/docs/notetaker-role.md) doc.
 
 ## Housekeeping section
 
-* 
+*
 
 ## Tasks
 
-* 
+*
 
 ## Meeting Minutes
 
-* 
+*
 
 ## Material
 
 Any material to read before the meeting should be included here.
 
-* 
+*
+```

--- a/docs/members.md
+++ b/docs/members.md
@@ -1,0 +1,5 @@
+# Member Directory
+
+The published RCN member directory is generated during the mdBook release workflow.
+
+See the current [RCN member list](https://rust-commercial-network.github.io/rcn/members.html).

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -6,6 +6,8 @@ The Rust Commercial Network (RCN) is a Rust Foundation group for people and orga
 
 **Join:** fill out the [membership application](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=membership%2Cstatus%3A+needs+review&projects=&template=membership.yml).
 
+**Members:** see the current [RCN member list](https://rust-commercial-network.github.io/rcn/members.html).
+
 **Discuss:** use the RCN channel in the [Rust Project Zulip](https://rust-lang.zulipchat.com/).
 
 **Support Rust ecosystem work:** see the [Funding Directory](./funding-directory.md).
@@ -65,9 +67,9 @@ RCN membership is free. See [Membership](./membership.md) for member definitions
 
 The Rust Foundation maintains the RCN with support from the RCN Steering Committee. See [Governance](./governance.md) for Steering Committee duties, composition, selection, terms, vacancies, and eligibility.
 
-## Code of Conduct
+## Policies
 
-The [Rust Foundation](https://rustfoundation.org/) has adopted a [Code of Conduct](https://foundation.rust-lang.org/policies/code-of-conduct/) that we expect RCN participants to adhere to. Please read the full text so that you can understand what actions will and will not be tolerated.
+RCN participants are expected to follow the Rust Foundation [Code of Conduct](https://foundation.rust-lang.org/policies/code-of-conduct/), the Rust Foundation [anti-trust policy](https://rustfoundation.org/policy/anti-trust-policy/), and the RCN [Conflict of Interest Policy](./conflict-of-interest-policy.md). Additional Rust Foundation policies are available on the [Rust Foundation website](https://rustfoundation.org/policies-resources/).
 
 ## Community Events
 
@@ -83,21 +85,3 @@ The Rust Foundation Member Summit, attached to RustConf, may provide one place f
 ## Contributing
 
 See [CONTRIBUTING.md](https://github.com/Rust-Commercial-Network/rcn/blob/main/CONTRIBUTING.md).
-
-## Licenses
-
-Rust is primarily distributed under the terms of both the MIT license and the Apache License (Version 2.0), with documentation portions covered by the Creative Commons Attribution 4.0 International license.
-
-See [LICENSE-APACHE](https://github.com/Rust-Commercial-Network/rcn/blob/main/LICENSE-APACHE), [LICENSE-MIT](https://github.com/Rust-Commercial-Network/rcn/blob/main/LICENSE-MIT), [LICENSE-documentation](https://github.com/Rust-Commercial-Network/rcn/blob/main/LICENSE-documentation), and [COPYRIGHT](https://github.com/Rust-Commercial-Network/rcn/blob/main/COPYRIGHT) for details.
-
-You can also read more under the Foundation's [intellectual property policy][ip-policy].
-
-## Other Policies
-
-Members of the RCN must adhere to the Rust Foundation's anti-trust policy [https://rustfoundation.org/policy/anti-trust-policy/](https://rustfoundation.org/policy/anti-trust-policy/) as you are a participant in the Foundation. Additional policies can be found on the [Rust Foundation website](https://rustfoundation.org/policies-resources/).
-
-[code-of-conduct]: https://rustfoundation.org/policy/code-of-conduct/
-[ip-policy]: https://rustfoundation.org/policy/intellectual-property-policy/
-[media-guide and trademark]: https://rustfoundation.org/policy/trademark-policy/
-[policies]: https://rustfoundation.org/policies-resources/
-[rust-foundation]: https://rustfoundation.org/

--- a/docs/rcn-meeting-notes-template.md
+++ b/docs/rcn-meeting-notes-template.md
@@ -1,3 +1,4 @@
+```markdown
 # RCN Meeting on \<date\> @ \<time\>
 
 | Search Key | Description |
@@ -8,7 +9,7 @@
 
 ## Agenda
 
-1. 
+1.
 
 ## Check-in area
 
@@ -18,24 +19,25 @@
 
 **Notetaker:**
 
-* 
+*
 
 For tips on how we take notes in the RCN, please see the [Meeting Notetaker Role](https://github.com/Rust-Commercial-Network/rcn/blob/main/docs/notetaker-role.md) doc.
 
 ## Housekeeping section
 
-* 
+*
 
 ## Tasks
 
-* 
+*
 
 ## Meeting Minutes
 
-* 
+*
 
 ## Material
 
 Any material to read before the meeting should be included here.
 
 *
+```


### PR DESCRIPTION
  - Cleaned up the mdBook landing page by removing license boilerplate and replacing scattered policy text with a concise participant policies section.
  - Promoted the member directory and funding directory into the top mdBook section
  - Added a local members.md placeholder for in-tree legibility
  - Updated template pages to render as raw Markdown code blocks so meeting templates are easier to copy and reuse.
  - Pointed README front-door links at the published mdBook pages where appropriate.