### PR TITLE
feat: split funding mdbook into multiple sections, add office hours

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The Rust Commercial Network (RCN) is a Rust Foundation group for people and orga
 
 **Rust Foundation:** see the [RCN page on the Rust Foundation site](https://rustfoundation.org/rust-commercial-network/).
 
-**Support Rust ecosystem work:** see the [Funding Directory](https://rust-commercial-network.github.io/rcn/funding-directory.html).
+**Support Rust ecosystem work:** see [Funding](https://rust-commercial-network.github.io/rcn/funding.html).
 
 ## Process Docs
 

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,7 +2,9 @@
 
 - [Overview](./overview.md)
 - [Member Directory](./members.md)
-- [Funding Directory](./funding-directory.md)
+- [Funding](./funding.md)
+  - [Funding Directory](./funding-directory.md)
+  - [Funding Office Hours](./funding-office-hours.md)
 
 # Process
 

--- a/docs/funding-directory.md
+++ b/docs/funding-directory.md
@@ -1,16 +1,16 @@
 # Rust Ecosystem Work Seeking Support
 
-This directory lists Rust compiler, Cargo, tooling, and library work where maintainers are looking for funding, production data, or feedback from companies using Rust at scale.
+This directory lists Rust ecosystem work seeking funding from companies using Rust at scale. It includes work on the Rust compiler, Cargo, tooling, libraries, and crates published on crates.io.
 
 The initiatives below represent active funding opportunities. Most already have at least one supporting organization and are looking for additional partners.
 
-To discuss funding, procurement, or sharing private production feedback, come to [Funding Initiative office hours][funding-office-hours-zulip]. For async public discussion, join us on [Rust Project Zulip][zulip]. For private discussion or to schedule private office hours, contact [rust-commercial-network@rustfoundation.org][rcn-email].
+To discuss funding, procurement, or sharing private production feedback, come to [Funding Initiative office hours](./funding-office-hours.md). For async public discussion, join us on the [commercial-network channel in Rust Project Zulip][zulip]. For private discussion or to schedule private office hours, contact [rust-commercial-network@rustfoundation.org][rcn-email].
 
 RFEF sponsors may receive recognition, fund reporting, sponsorship coordination, and advance security disclosures when coordinated private notice is needed.
 
 ## How to Help
 
-Most listed work can be supported through the Rust Foundation Ecosystem Fund (RFEF), which directs funding to the maintainers or projects doing the work. For Rust Project goals seeking support, see the [Rust Project Goals funding page][project-goals-funding]. If an organization wants to support Rust maintainers more generally, please check out the  [Rust Project Funding page](https://rust-lang.org/funding/) where you can support the Rust Foundation Maintainers Fund or individual Rust project members.
+Most listed work can be supported through the Rust Foundation Ecosystem Fund (RFEF), which directs funding to the maintainers or projects doing the work. For all Rust Project goals seeking support, see the [Rust Project Goals funding page][project-goals-funding]. If an organization wants to support Rust maintainers more generally, please check out the  [Rust Project Funding page](https://rust-lang.org/funding/) where you can support the Rust Foundation Maintainers Fund or individual Rust project members.
 
 Funding does not buy control over Rust technical decisions, RFC outcomes, stabilization, release timing, maintainer review, priority, or project roadmaps.
 
@@ -260,7 +260,7 @@ Related: [Hyperium Roadmap][hyperium-roadmap].
 
 ## Contact
 
-To discuss funding, procurement, or private production feedback, come to [Funding Initiative office hours][funding-office-hours-zulip]. For async public discussion, join us on [Rust Project Zulip][zulip]. For private discussion or to schedule private office hours, contact [rust-commercial-network@rustfoundation.org][rcn-email].
+To discuss funding, procurement, or private production feedback, come to [Funding Initiative office hours](./funding-office-hours.md). For async public discussion, join us on the [commercial-network channel in Rust Project Zulip][zulip]. For private discussion or to schedule private office hours, contact [rust-commercial-network@rustfoundation.org][rcn-email].
 
 [async-fn-traits]: https://rust-lang.github.io/rust-project-goals/2026/afidt-box.html#funding
 [async-state-machine-background]: https://tweedegolf.nl/en/blog/237/async-rust-never-left-the-mvp-state
@@ -277,7 +277,6 @@ To discuss funding, procurement, or private production feedback, come to [Fundin
 [declarative-macro-improvements]: https://github.com/rust-lang/rust-project-goals/issues/629
 [faster-builds-roadmap]: https://rust-lang.github.io/rust-project-goals/2026/roadmap-fast-builds.html
 [folkertdev]: https://github.com/folkertdev
-[funding-office-hours-zulip]: https://rust-lang.zulipchat.com/#narrow/channel/594428-commercial-network/topic/Funding.20Initiative.20.2F.20office.20hours/with/607451311
 [hyperium]: https://hyper.rs/
 [hyperium-roadmap]: https://hyper.rs/contrib/roadmap/
 [incremental-system-rethought]: https://rust-lang.github.io/rust-project-goals/2026/incremental-system-rethought.html
@@ -292,4 +291,4 @@ To discuss funding, procurement, or private production feedback, come to [Fundin
 [tokio-coop-prototype]: https://github.com/tokio-rs/tokio/tree/time-based-coop-poc
 [tokio-runtime-discussion]: https://github.com/tokio-rs/tokio/issues/8085
 [tweede-golf]: https://tweedegolf.nl/
-[zulip]: https://rust-lang.zulipchat.com/
+[zulip]: https://rust-lang.zulipchat.com/#narrow/channel/594428-commercial-network

--- a/docs/funding-directory.md
+++ b/docs/funding-directory.md
@@ -4,7 +4,7 @@ This directory lists Rust compiler, Cargo, tooling, and library work where maint
 
 The initiatives below represent active funding opportunities. Most already have at least one supporting organization and are looking for additional partners.
 
-To discuss funding, procurement, or sharing private production feedback, contact [rust-commercial-network@rustfoundation.org][rcn-email]. For public discussion, use the [RCN channel in the Rust Project Zulip][rcn-zulip].
+To discuss funding, procurement, or sharing private production feedback, come to [Funding Initiative office hours][funding-office-hours-zulip]. For async public discussion, join us on [Rust Project Zulip][zulip]. For private discussion or to schedule private office hours, contact [rust-commercial-network@rustfoundation.org][rcn-email].
 
 RFEF sponsors may receive recognition, fund reporting, sponsorship coordination, and advance security disclosures when coordinated private notice is needed.
 
@@ -260,7 +260,7 @@ Related: [Hyperium Roadmap][hyperium-roadmap].
 
 ## Contact
 
-To discuss funding, procurement, or private production feedback, contact [rust-commercial-network@rustfoundation.org][rcn-email]. For public discussion, use the [RCN channel in the Rust Project Zulip][rcn-zulip].
+To discuss funding, procurement, or private production feedback, come to [Funding Initiative office hours][funding-office-hours-zulip]. For async public discussion, join us on [Rust Project Zulip][zulip]. For private discussion or to schedule private office hours, contact [rust-commercial-network@rustfoundation.org][rcn-email].
 
 [async-fn-traits]: https://rust-lang.github.io/rust-project-goals/2026/afidt-box.html#funding
 [async-state-machine-background]: https://tweedegolf.nl/en/blog/237/async-rust-never-left-the-mvp-state
@@ -277,13 +277,13 @@ To discuss funding, procurement, or private production feedback, contact [rust-c
 [declarative-macro-improvements]: https://github.com/rust-lang/rust-project-goals/issues/629
 [faster-builds-roadmap]: https://rust-lang.github.io/rust-project-goals/2026/roadmap-fast-builds.html
 [folkertdev]: https://github.com/folkertdev
+[funding-office-hours-zulip]: https://rust-lang.zulipchat.com/#narrow/channel/594428-commercial-network/topic/Funding.20Initiative.20.2F.20office.20hours/with/607451311
 [hyperium]: https://hyper.rs/
 [hyperium-roadmap]: https://hyper.rs/contrib/roadmap/
 [incremental-system-rethought]: https://rust-lang.github.io/rust-project-goals/2026/incremental-system-rethought.html
 [open-namespaces-goal]: https://rust-lang.github.io/rust-project-goals/2025h1/open-namespaces.html
 [project-goals-funding]: https://rust-lang.github.io/rust-project-goals/2026/funding.html
 [rcn-email]: mailto:rust-commercial-network@rustfoundation.org
-[rcn-zulip]: https://rust-lang.zulipchat.com/#narrow/channel/594428-rcn
 [rfc-3243]: https://github.com/rust-lang/rfcs/issues/3243
 [rust-lang-rust]: https://github.com/rust-lang/rust
 [rustls]: https://rustls.dev/
@@ -292,3 +292,4 @@ To discuss funding, procurement, or private production feedback, contact [rust-c
 [tokio-coop-prototype]: https://github.com/tokio-rs/tokio/tree/time-based-coop-poc
 [tokio-runtime-discussion]: https://github.com/tokio-rs/tokio/issues/8085
 [tweede-golf]: https://tweedegolf.nl/
+[zulip]: https://rust-lang.zulipchat.com/

--- a/docs/funding-office-hours.md
+++ b/docs/funding-office-hours.md
@@ -1,0 +1,20 @@
+# Funding Initiative Office Hours
+
+Funding Initiative office hours are for RCN members working on Rust ecosystem funding from the sponsor side.
+
+They are for sponsors and potential sponsors, not for projects seeking funding.
+
+Use office hours to:
+
+* Match a budget to funding opportunities
+* Prepare an internal funding pitch
+* Work through sponsorship logistics
+* Ask about items in the [Funding Directory](./funding-directory.md)
+
+The first office hours are scheduled for July 8, 2026 at 8:00 AM Pacific on the RCN calendar. Scheduling and agenda discussion happen in the [Funding Initiative office hours Zulip thread][funding-office-hours-zulip].
+
+For async public discussion outside office hours, join us on the [commercial-network channel in Rust Project Zulip][zulip]. For private discussion or to schedule private office hours, contact [rust-commercial-network@rustfoundation.org][rcn-email].
+
+[funding-office-hours-zulip]: https://rust-lang.zulipchat.com/#narrow/channel/594428-commercial-network/topic/Funding.20Initiative.20.2F.20office.20hours/with/607451311
+[rcn-email]: mailto:rust-commercial-network@rustfoundation.org
+[zulip]: https://rust-lang.zulipchat.com/#narrow/channel/594428-commercial-network

--- a/docs/funding.md
+++ b/docs/funding.md
@@ -1,0 +1,20 @@
+# Funding
+
+Does your company depend on Rust?
+
+The Funding Initiative is for RCN members who want to fund maintainer time for both directed work and maintenance in the Rust ecosystem.
+
+If your organization has budget, or you need help making the case for one, come to [Funding Initiative office hours](./funding-office-hours.md). Office hours are for sponsors and potential sponsors, not for projects seeking funding.
+
+Small and large contributions are welcome. If you cannot discuss something publicly, email [rust-commercial-network@rustfoundation.org][rcn-email] and we can schedule a private conversation. For async public discussion, use the [commercial-network channel in Rust Project Zulip][zulip].
+
+## Funding Directory
+
+The [Funding Directory](./funding-directory.md) lists open funding opportunities, including project work, ongoing maintenance, reviews, and project support.
+
+## Office Hours
+
+[Funding Initiative office hours](./funding-office-hours.md) are for routing a budget, preparing an internal funding pitch, and working through sponsorship logistics.
+
+[rcn-email]: mailto:rust-commercial-network@rustfoundation.org
+[zulip]: https://rust-lang.zulipchat.com/#narrow/channel/594428-commercial-network

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -14,7 +14,7 @@ The Rust Commercial Network (RCN) is a Rust Foundation group for people and orga
 
 **Rust Foundation:** see the [RCN page on the Rust Foundation site](https://rustfoundation.org/rust-commercial-network/).
 
-**Support Rust ecosystem work:** see the [Funding Directory](./funding-directory.md).
+**Support Rust ecosystem work:** see [Funding](./funding.md).
 
 ## Overview
 
@@ -83,7 +83,7 @@ The Rust Foundation Member Summit, attached to RustConf, may provide one place f
 
 * [Apply to join the RCN](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=membership%2Cstatus%3A+needs+review&projects=&template=membership.yml)
 * [Propose an initiative](https://github.com/Rust-Commercial-Network/rcn/issues/new?assignees=lorilorusso&labels=initiative-proposal%2Cstatus%3A+needs+review&projects=&template=initiative_proposal.yml)
-* [Support Rust ecosystem work](./funding-directory.md)
+* [Support Rust ecosystem work](./funding.md)
 * Join the RCN channel in the [Rust Project Zulip](https://rust-lang.zulipchat.com/)
 
 ## Contributing

--- a/meetings/2026-06-22.md
+++ b/meetings/2026-06-22.md
@@ -52,7 +52,7 @@ Agenda
          3. Lori will put the meeting on the [RCN Calendar](https://bit.ly/4xngeHr) (all meetings will be listed here)  
       3. Based on the level of participation create a [Rust Commercial Network Initiative Proposal issue](https://github.com/Rust-Commercial-Network/rcn/issues)  
 5. Funding   
-   1. [RCN Funding Directory](https://rust-commercial-network.github.io/rcn/funding-directory.html)  
+   1. [RCN Funding](https://rust-commercial-network.github.io/rcn/funding.html)
    2. Project Goals \- [https://rust-lang.github.io/rust-project-goals/2025h2/goals.html](https://rust-lang.github.io/rust-project-goals/2025h2/goals.html)   
       1. [Funding opportunities](https://rust-lang.github.io/rust-project-goals/2026/funding.html)  
    3. [Rust Foundation Maintainers Fund](https://rust-lang.org/funding/)  


### PR DESCRIPTION
Overhauling to have a standalone landing that routes to office hours and directory pages.