### PR TITLE
Member workflow dispatch

### DIFF
--- a/.github/workflows/mdbook.yml
+++ b/.github/workflows/mdbook.yml
@@ -5,6 +5,10 @@ name: Deploy mdBook
 on:
   push:
     branches: [main]
+  schedule:
+    # Every 6 hours: picks up member directory changes made directly on the
+    # project board (corrections, removals) that don't dispatch a rebuild.
+    - cron: "23 */6 * * *"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/membership-approved.yml
+++ b/.github/workflows/membership-approved.yml
@@ -89,6 +89,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       issues: write
+      actions: write
 
     steps:
       - name: Verify sender is assignee or admin
@@ -417,3 +418,18 @@ jobs:
             });
 
             core.info('Masked the public email address in the issue body.');
+
+      - name: Trigger website rebuild
+        uses: actions/github-script@v7
+        with:
+          script: |
+            // Regenerate the published member directory so the new member
+            // shows up without waiting for the next push to main.
+            await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'mdbook.yml',
+              ref: 'main',
+            });
+
+            core.info('Dispatched the Deploy mdBook workflow.');


### PR DESCRIPTION
Previously our mdbook only regenerated on manual workflow dispatch or push to main. This change also triggers dispatch to the mdbook workflow after updating the project board. 

As a fallback, we also regenerate every 6 hours.